### PR TITLE
fix link of "back to lightning talks" page

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -79,7 +79,7 @@ color: dark-nav
 
       {% if page.category == 'lightning' %}
         <a
-          href='{{site.baseurl}}/lightning-talks'
+          href='{{site.baseurl}}/lightning_talks'
           class='button pad2x stroke icon prev space-top4 round-big'>Back to lightning talks</a>
 
       {% else %}


### PR DESCRIPTION
currently, the "back …" links from all lightning talks pages end up in a 404 (for example here: https://2018.stateofthemap.org/2018/L046-The_Telenav_Metrics_Dashboard_for_OpenStreetMap/)

this may have to be adapted in other places as well:

* https://github.com/openstreetmap/stateofthemap-2018/blob/gh-pages/_includes/slot-item.html 
* https://github.com/openstreetmap/stateofthemap-2018/blob/gh-pages/_includes/slot-item-middle.html
* https://github.com/tyrasd/stateofthemap-2018/blob/patch-1/_layouts/it/eventit.html