### PR TITLE
Fix commenting style on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ role: index
 
 {% include header.html %}
 {% include about.html %}
-<!-- {% include announce.html %} -->
-<!-- {% include videos.html %} -->
+{% comment %}{% include announce.html %}{% endcomment %}
+{% comment %}{% include videos.html %}{% endcomment %}
 {% include newsletter.html %}
 {% include map.html %}
 {% include sponsors.html %}


### PR DESCRIPTION
Swap to use jekyll style comments instead of HTML comments on the homepage. Simple change which fixes a bug:

Currently you can see a white bar and spurious '-->' appearing on the homepage. That was caused by this commit https://github.com/openstreetmap/stateofthemap-2018/commit/66a93bf430d21ea5c4b446e9d2116a3b11a1bd0d#diff-eacf331f0ffc35d4b482f1d15a887d3b in which we are trying to use HTML style comments to remove the 'announce' bar. It didn't work because the announce template itself has a small HTML comment here: https://github.com/openstreetmap/stateofthemap-2018/blob/gh-pages/_includes/announce.html#L1  ...and a HTML comment within a comment results in brokenness.

So as well as a spurious '-->', the intention of that commit was to remove the 'announce' bar ("Call for posters" and "Tickets" bits), and currently these are still showing.

Here we solve all this by making these outer comments jekyll style comments.

This is better also because it totally disables rendering of the includes, so less commented out html mess being put on the rendered page.